### PR TITLE
Fix typo in function name

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@
 - Fills out acceptance criteria
 - Tested manually and automatically
 
-Sovellus on testattavissa [Azuressa](https://manaatit.azurewebsites.net/)
+Sovellus on testattavissa [Azuressa](https://manaatit.azurewebsites.net/) 

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@
 - Fills out acceptance criteria
 - Tested manually and automatically
 
-Sovellus on testattavissa [Azuressa](https://manaatit.azurewebsites.net/) 
+Sovellus on testattavissa [Azuressa](https://manaatit.azurewebsites.net/)

--- a/app/services/bibtex_service.py
+++ b/app/services/bibtex_service.py
@@ -13,7 +13,7 @@ class BibtexService:
             bibtex_str += self._stringify_book(book)
 
         for article in self._articles:
-            bibtex_str += self._stringity_article(article)
+            bibtex_str += self._stringify_article(article)
 
         return bibtex_str
 
@@ -32,7 +32,7 @@ class BibtexService:
             f''
         )
 
-    def _stringity_article(self, article):
+    def _stringify_article(self, article):
         return (
             f"@article{{{article[1]},\n"
             f"  title = \"{article[2]}\",\n"


### PR DESCRIPTION
Fixed typo `_stringity_article` > `_stringify_article`.